### PR TITLE
Swapping `label` for `append` so consumer can pass down anything they want

### DIFF
--- a/src-docs/src/views/suggest/suggest.js
+++ b/src-docs/src/views/suggest/suggest.js
@@ -133,6 +133,8 @@ export default class extends Component {
       </EuiPopover>
     );
 
+    const append = <EuiButtonEmpty>KQL</EuiButtonEmpty>;
+
     return (
       <div>
         <EuiFlexGroup>
@@ -151,7 +153,7 @@ export default class extends Component {
             <EuiSuggest
               status={this.state.status}
               prefix={hashtag}
-              label={'KQL'}
+              append={append}
               suggestions={sampleItems}
             />
           </EuiFlexItem>

--- a/src/components/suggest/_suggest_input.scss
+++ b/src/components/suggest/_suggest_input.scss
@@ -6,11 +6,8 @@
     margin-right: $euiSizeS;
   }
   .statusIcon {
-    display: flex;
-    .statusLabel {
-      padding-left: $euiSizeS;
-      padding-right: $euiSizeS;
-    }
+    padding-left: $euiSizeS;
+    padding-right: $euiSizeS;
   }
 }
 

--- a/src/components/suggest/suggest.js
+++ b/src/components/suggest/suggest.js
@@ -37,26 +37,26 @@ export class EuiSuggest extends Component {
     const {
       className,
       status,
-      label,
       prefix,
+      append,
       suggestions,
       ...rest
     } = this.props;
 
-    const suggestionList = (suggestions.map((item, index) => (
+    const suggestionList = suggestions.map((item, index) => (
       <EuiSuggestItem
         type={item.type}
         key={index}
         label={item.label}
         description={item.description}
       />
-    )));
+    ));
 
     const suggestInput = (
       <EuiSuggestInput
         status={status}
-        label={label}
         prefix={prefix}
+        append={append}
         sendValue={this.getValue}
         suggestions={suggestionList}
       />
@@ -78,11 +78,11 @@ EuiSuggest.propTypes = {
     'isLoading',
   ]),
   /**
-   * Label that goes next to the status element (e.g. KQL).
-   */
-  label: PropTypes.node,
-  /**
    * Element to be appended to the input bar.
+   */
+  append: PropTypes.node,
+  /**
+   * Element to be prepended to the input bar.
    */
   prefix: PropTypes.node,
   /**

--- a/src/components/suggest/suggest_input.js
+++ b/src/components/suggest/suggest_input.js
@@ -36,7 +36,7 @@ export class EuiSuggestInput extends Component {
     const {
       className,
       status,
-      label,
+      append,
       prefix,
       suggestions,
       sendValue,
@@ -68,26 +68,32 @@ export class EuiSuggestInput extends Component {
       color = statusMap[status].color;
       tooltip = statusMap[status].tooltip;
     }
-    const statusElement = (
-      <EuiToolTip position="left" content={tooltip}>
-        {status !== 'isLoading' ? (
-          <div className="statusIcon">
-            <EuiIcon color={color} type={icon} />
-            <div className="statusLabel">{label}</div>
-          </div>
-        ) : (
-          <span />
-        )}
+    const classes = classNames('euiSuggestInput', className);
+
+    // EuiFieldText's append accepts an array of elements so start by creating an empty arry
+    const appendArray = [];
+
+    const statusElement = status !== 'isLoading' && (
+      <EuiToolTip
+        position="left"
+        content={tooltip}
+        anchorClassName="statusIcon">
+        <EuiIcon color={color} type={icon} />
       </EuiToolTip>
     );
-    const classes = classNames('euiSuggestInput', className);
+
+    // Push the status element to the array if it is not undefined
+    if (statusElement) appendArray.push(statusElement);
+
+    // Check to see if consumer passed an append item and if so, add it to the array
+    if (append) appendArray.push(append);
 
     const customInput = (
       <EuiFieldText
         value={this.state.value}
         fullWidth
         prepend={prefix}
-        append={statusElement}
+        append={appendArray}
         isLoading={status === 'isLoading' ? true : false}
         onChange={this.onFieldChange.bind(this)}
         {...rest}
@@ -121,11 +127,11 @@ EuiSuggestInput.propTypes = {
     'isLoading',
   ]),
   /**
-   * Label that goes next to the status element (e.g. KQL).
-   */
-  label: PropTypes.node,
-  /**
    * Element to be appended to the input bar.
+   */
+  append: PropTypes.node,
+  /**
+   * Element to be prepended to the input bar.
    */
   prefix: PropTypes.node,
   /**


### PR DESCRIPTION
Essentially, I removed the `label` prop because it only ever displayed with the icon and while it accepted more than a just a string, it didn't properly behave like the typical input appends.

Now, consumers can pass down any React element (not a string, but they can always wrap a string with spans) and the SuggestInput will properly pass it down to EuiFieldText which accepts one or an array of elements to its `append` prop. Similar to the `prepend` prop.