### PR TITLE
TypeScript cleanup

### DIFF
--- a/src/components/basic_table/basic_table.tsx
+++ b/src/components/basic_table/basic_table.tsx
@@ -16,11 +16,11 @@ import { CommonProps } from '../common';
 import { isFunction } from '../../services/predicate';
 import { get } from '../../services/objects';
 import { EuiFlexGroup, EuiFlexItem } from '../flex';
-// @ts-ignore
 import { EuiCheckbox } from '../form/checkbox/checkbox';
 
 import {
   EuiTable,
+  EuiTableProps,
   EuiTableBody,
   EuiTableFooter,
   EuiTableFooterCell,
@@ -32,7 +32,6 @@ import {
   EuiTableRowCell,
   EuiTableRowCellCheckbox,
   EuiTableSortMobile,
-  LayoutType,
 } from '../table';
 
 import { CollapsedItemActions } from './collapsed_item_actions';
@@ -172,13 +171,12 @@ export interface CriteriaWithPagination<T> extends Criteria<T> {
 type CellPropsCallback<T> = (item: T, column: EuiBasicTableColumn<T>) => object;
 type RowPropsCallback<T> = (item: T) => object;
 
-interface BasicTableProps<T> {
+interface BasicTableProps<T> extends Omit<EuiTableProps, 'onChange'> {
   itemId?: ItemId<T>;
   itemIdToExpandedRowMap?: ItemIdToExpandedRowMap;
   items: T[];
   cellProps?: object | CellPropsCallback<T>;
   columns: Array<EuiBasicTableColumn<T>>;
-  compressed?: boolean;
   error?: string;
   hasActions?: boolean;
   isExpandable?: boolean;
@@ -187,11 +185,9 @@ interface BasicTableProps<T> {
   noItemsMessage?: ReactNode;
   onChange?: (criteria: Criteria<T>) => void;
   pagination?: undefined;
-  responsive?: boolean;
   rowProps?: object | RowPropsCallback<T>;
   selection?: EuiTableSelectionType<T>;
   sorting?: EuiTableSortingType<T>;
-  tableLayout?: LayoutType;
 }
 
 type BasicTableWithPaginationProps<T> = Omit<
@@ -362,24 +358,24 @@ export class EuiBasicTable<T = any> extends Component<
     const {
       className,
       loading,
-      items, // eslint-disable-line no-unused-vars
-      itemId, // eslint-disable-line no-unused-vars
-      columns, // eslint-disable-line no-unused-vars
-      pagination, // eslint-disable-line no-unused-vars
-      sorting, // eslint-disable-line no-unused-vars
-      selection, // eslint-disable-line no-unused-vars
-      onChange, // eslint-disable-line no-unused-vars
-      error, // eslint-disable-line no-unused-vars
-      noItemsMessage, // eslint-disable-line no-unused-vars
-      compressed, // eslint-disable-line no-unused-vars
-      itemIdToExpandedRowMap, // eslint-disable-line no-unused-vars
-      responsive, // eslint-disable-line no-unused-vars
-      isSelectable, // eslint-disable-line no-unused-vars
-      isExpandable, // eslint-disable-line no-unused-vars
-      hasActions, // eslint-disable-line no-unused-vars
-      rowProps, // eslint-disable-line no-unused-vars
-      cellProps, // eslint-disable-line no-unused-vars
-      tableLayout, // eslint-disable-line no-unused-vars
+      items,
+      itemId,
+      columns,
+      pagination,
+      sorting,
+      selection,
+      onChange,
+      error,
+      noItemsMessage,
+      compressed,
+      itemIdToExpandedRowMap,
+      responsive,
+      isSelectable,
+      isExpandable,
+      hasActions,
+      rowProps,
+      cellProps,
+      tableLayout,
       ...rest
     } = this.props;
 

--- a/src/components/basic_table/in_memory_table.tsx
+++ b/src/components/basic_table/in_memory_table.tsx
@@ -22,7 +22,6 @@ import { Comparators, Direction } from '../../services/sort';
 import { EuiSearchBar } from '../search_bar';
 import { EuiSpacer } from '../spacer';
 import { CommonProps } from '../common';
-import { LayoutType } from '../table';
 
 // Search bar types. Should be moved when it is typescriptified.
 interface SearchBoxConfig {
@@ -190,7 +189,6 @@ type InMemoryTableProps<T> = Omit<
     isClauseMatcher?: (...args: any) => boolean;
     explain?: boolean;
   };
-  tableLayout?: LayoutType;
 };
 
 type InMemoryTablePropsWithPagination<T> = Omit<
@@ -587,11 +585,11 @@ export class EuiInMemoryTable<T> extends Component<
       rowProps,
       cellProps,
       tableLayout,
-      items: _unuseditems, // eslint-disable-line no-unused-vars
-      search, // eslint-disable-line no-unused-vars
-      onTableChange, // eslint-disable-line no-unused-vars
-      executeQueryOptions, // eslint-disable-line no-unused-vars
-      allowNeutralSort, // eslint-disable-line no-unused-vars
+      items: _unuseditems,
+      search,
+      onTableChange,
+      executeQueryOptions,
+      allowNeutralSort,
       ...rest
     } = this.props;
 

--- a/src/components/table/index.ts
+++ b/src/components/table/index.ts
@@ -1,5 +1,4 @@
-export { EuiTable, Props as EuiTableProps } from './table';
-export { LayoutType } from './table';
+export { EuiTable, EuiTableProps } from './table';
 export { EuiTableBody } from './table_body';
 export { EuiTableFooter } from './table_footer';
 export { EuiTableFooterCell } from './table_footer_cell';

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -2,24 +2,23 @@ import React, { FunctionComponent, TableHTMLAttributes } from 'react';
 import classNames from 'classnames';
 import { CommonProps } from '../common';
 
-export type Props = {
+export interface EuiTableProps
+  extends CommonProps,
+    TableHTMLAttributes<HTMLTableElement> {
   compressed?: boolean;
   responsive?: boolean;
   /**
    * Sets the table-layout CSS property
    */
-  tableLayout?: LayoutType;
-} & CommonProps &
-  TableHTMLAttributes<HTMLTableElement>;
-
-export type LayoutType = 'fixed' | 'auto';
+  tableLayout?: 'fixed' | 'auto';
+}
 
 const tableLayoutToClassMap: { [tableLayout: string]: string | null } = {
   fixed: null,
   auto: 'euiTable--auto',
 };
 
-export const EuiTable: FunctionComponent<Props> = ({
+export const EuiTable: FunctionComponent<EuiTableProps> = ({
   children,
   className,
   compressed,


### PR DESCRIPTION
### Summary

* Does a better job of exporting `EuiTableProps`
* Uses `EuiTableProps`as the base for defining `BasicTableProps` and (by proxy)  `InMemoryTableProps`
* Misc. cleanup of linter comments that are no longer helpful (doesn't have anything to do with your PR; I just don't like them 😄)