### PR TITLE
Tidying CSS a bit and fixing IE and responsiveness

### DIFF
--- a/src/components/comment/_comment_event.scss
+++ b/src/components/comment/_comment_event.scss
@@ -2,74 +2,56 @@
 
 .euiCommentEvent {
   overflow: hidden;
+}
 
-  .euiCommentEvent__header {
-    @include euiBreakpoint('xs', 's') {
-      margin: -($euiSizeXS);
+.euiCommentEvent__header {
+  line-height: $euiLineHeight;
+  display: flex;
+  align-items: center;
+}
 
-      > div {
-        margin: $euiSizeXS;
-      }
+.euiCommentEvent__headerData {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
 
-      .euiCommentEvent__headerTimestamp {
-        padding-top: $euiSizeXS * .5;
-      }
-    }
-
-    align-items: center;
-
-    .euiCommentEvent__headerData > div {
-      padding-right: $euiSizeXS;
-    }
+  > div {
+    padding-right: $euiSizeXS;
   }
+}
 
-  .euiCommentEvent__headerData {
-    align-items: center;
-    display: flex;
-    flex-wrap: wrap;
-  }
-
-  .euiCommentEvent__headerUsername {
-    font-weight: $euiFontWeightSemiBold;
-  }
-
+.euiCommentEvent__headerUsername {
+  font-weight: $euiFontWeightSemiBold;
 }
 
 .euiCommentEvent--regular {
   border: $euiBorderThin;
 
   .euiCommentEvent__header {
-    @include euiBreakpoint('xs', 's') {
-      padding: $euiSizeS;
+    min-height: $euiSizeXXL;
+    background-color: $euiColorLightestShade;
+    border-bottom: $euiBorderThin;
+    padding: $euiSizeXS $euiSizeS;
 
-      /**
-       * Fix for IE when using align-items:center in an item that has min-height
-            (https://github.com/philipwalton/flexbugs/issues/231#issuecomment-362790042)
-       */
+    /**
+     * Fix for IE when using align-items:center in an item that has min-height
+        (https://github.com/philipwalton/flexbugs/issues/231#issuecomment-362790042)
+     */
+    // sass-lint:disable-block mixins-before-declarations
+    @include internetExplorerOnly {
       &::after {
         content: '';
-        min-height: inherit;
+        // Calculates the minimum height based on full header's min-height minus the vertical padding
+        min-height: $euiSizeXXL - $euiSizeS;
         font-size: 0;
         display: block;
       }
     }
+  }
 
-    /**
-      * Fix for IE when using align-items:center in an item that has min-height
-          (https://github.com/philipwalton/flexbugs/issues/231#issue-245848315)
-      */
-    @include euiBreakpoint('m', 'l', 'xl') {
-      height: $euiSize;
-    }
-
-    min-height: $euiSizeXXL;
-    background-color: $euiColorLightestShade;
-    border-bottom: $euiBorderThin;
-    padding: 0 $euiSizeS;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-
+  .euiCommentEvent__headerData {
+    // Push the actions far right
+    flex-grow: 1;
   }
 
   .euiCommentEvent__body {
@@ -79,7 +61,6 @@
 
 .euiCommentEvent--update {
   .euiCommentEvent__header {
-    display: flex;
     justify-content: flex-start;
     padding: $euiSizeXS 0;
   }


### PR DESCRIPTION
I'll comment what I did in the diff, but essentially the flex and padding changes also fix mobile so you don't need special small screen styles.

_All screenshots are IE, but look the same in Chrome_

**Without actions**

<img width="972" alt="Screen Shot 2020-04-06 at 16 45 37 PM" src="https://user-images.githubusercontent.com/549577/78603654-7da0c500-7826-11ea-90ed-5c7dbe6c620f.png">

**With actions**

<img width="971" alt="Screen Shot 2020-04-06 at 16 47 41 PM" src="https://user-images.githubusercontent.com/549577/78603648-7bd70180-7826-11ea-9608-55a726aabd31.png">


**Small screens**

<img width="368" alt="Screen Shot 2020-04-06 at 16 48 04 PM" src="https://user-images.githubusercontent.com/549577/78603644-78dc1100-7826-11ea-98de-4600ce07b883.png">
<img width="365" alt="Screen Shot 2020-04-06 at 16 48 18 PM" src="https://user-images.githubusercontent.com/549577/78603645-7974a780-7826-11ea-8221-dd9f7d61fd05.png">

