### PR TITLE
Simple fix for tuncation and padding of value text

### DIFF
--- a/src-docs/src/views/progress/progress_chart.js
+++ b/src-docs/src/views/progress/progress_chart.js
@@ -3,25 +3,27 @@ import React, { Fragment } from 'react';
 import { EuiProgress, EuiSpacer } from '../../../../src/components';
 
 const data = [
-  { label: "Men's Clothing", value: '80' },
-  { label: "Women's Clothing", value: '60' },
-  { label: "Women's Shoes", value: '45' },
-  { label: "Men's Shoes", value: '40' },
+  { label: 'Basic percentage', value: '80' },
+  {
+    label: 'Long percentage',
+    value: '60.0703850454546453168415365451354641354684531',
+  },
+  { label: 'Another basic percent', value: '45' },
+  { label: 'Custom valueText', value: '40', valueText: <span>4,005,678</span> },
   { label: "Women's Accessories", value: '24' },
 ];
 
 export default () => (
   <Fragment>
-    <div style={{ maxWidth: 140 }}>
+    <div style={{ maxWidth: 160 }}>
       {data.map(item => (
         <>
           <EuiProgress
-            label={item.label}
             valueText={true}
-            value={item.value}
             max={100}
             color="secondary"
             size="s"
+            {...item}
           />
           <EuiSpacer size="s" />
         </>
@@ -32,12 +34,11 @@ export default () => (
       {data.map(item => (
         <>
           <EuiProgress
-            label={item.label}
             valueText={true}
-            value={item.value}
             max={100}
             color="primary"
             size="m"
+            {...item}
           />
           <EuiSpacer size="s" />
         </>

--- a/src-docs/src/views/progress/progress_chart.js
+++ b/src-docs/src/views/progress/progress_chart.js
@@ -10,7 +10,7 @@ const data = [
   },
   { label: 'Another basic percent', value: '45' },
   { label: 'Custom valueText', value: '40', valueText: <span>4,005,678</span> },
-  { label: "Women's Accessories", value: '24' },
+  { label: "Women's Accessories", value: '24.0256' },
 ];
 
 export default () => (

--- a/src/components/progress/__snapshots__/progress.test.tsx.snap
+++ b/src/components/progress/__snapshots__/progress.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`EuiProgress has value 1`] = `
 exports[`EuiProgress has valueText and label 1`] = `
 Array [
   <div
-    class="euiProgress__data euiProgress__data--hasLabel euiProgress__data--secondary"
+    class="euiProgress__data euiProgress__data--secondary"
   >
     <span
       class="euiProgress__label"

--- a/src/components/progress/_progress.scss
+++ b/src/components/progress/_progress.scss
@@ -120,7 +120,7 @@ $euiProgressColors: (
 
   .euiProgress__data--#{$name} {
     .euiProgress__valueText {
-      color: $color;
+      color: makeHighContrastColor($color);
     }
   }
 }
@@ -137,39 +137,39 @@ $euiProgressColors: (
 
 .euiProgress__data {
   display: flex;
+  justify-content: space-between;
 
-  .euiProgress__valueText {
-    margin-left: auto;
+  .euiProgress__label {
+    @include euiTextTruncate;
+    flex-grow: 1;
+
+    // Only restrict the valueText if it's the sibling of the label
+    // Gives width precedence to the value text forcing consumers to round their values
+    + .euiProgress__valueText {
+      padding-left: $euiSizeXS;
+      flex-grow: 1;
+      text-align: right;
+      flex-shrink: 0;
+    }
   }
 }
 
-.euiProgress__data--hasLabel {
-  margin: -$euiSizeXS * .5;
-
-  .euiProgress__label {
-    margin: $euiSizeXS * .5;
-    flex-basis: 0%;
-    flex-grow: 1;
-  }
-
-  .euiProgress__valueText {
-    margin: $euiSizeXS * .5;
-    flex-basis: auto;
-    flex-grow: 0;
-  }
+.euiProgress__valueText {
+  @include euiTextTruncate;
+  // Tabular numbers ensure the line up nicely when right-aligned
+  font-feature-settings: 'tnum' 1;
+  text-align: right;
 }
 
 .euiProgress__label,
 .euiProgress__valueText {
   @include euiText;
-  @include euiFontSize;
-  @include euiTextTruncate;
-  @include fontSize($euiFontSizeXS);
+  @include euiFontSizeXS;
 }
 
 .euiProgress__data--l {
   .euiProgress__label,
   .euiProgress__valueText {
-    @include fontSize($euiFontSizeS);
+    @include euiFontSizeS;
   }
 }

--- a/src/components/progress/_progress.scss
+++ b/src/components/progress/_progress.scss
@@ -138,33 +138,31 @@ $euiProgressColors: (
 .euiProgress__data {
   display: flex;
   justify-content: space-between;
-
-  .euiProgress__label {
-    @include euiTextTruncate;
-    flex-grow: 1;
-
-    // Only restrict the valueText if it's the sibling of the label
-    // Gives width precedence to the value text forcing consumers to round their values
-    + .euiProgress__valueText {
-      padding-left: $euiSizeXS;
-      flex-grow: 1;
-      text-align: right;
-      flex-shrink: 0;
-    }
-  }
-}
-
-.euiProgress__valueText {
-  @include euiTextTruncate;
-  // Tabular numbers ensure the line up nicely when right-aligned
-  font-feature-settings: 'tnum' 1;
-  text-align: right;
 }
 
 .euiProgress__label,
 .euiProgress__valueText {
   @include euiText;
   @include euiFontSizeXS;
+  @include euiTextTruncate;
+}
+
+.euiProgress__label {
+  flex-grow: 1;
+
+  // Only restrict the valueText if it's the sibling of the label
+  // Gives width precedence to the value text forcing consumers to round their values
+  + .euiProgress__valueText {
+    padding-left: $euiSizeXS;
+    flex-grow: 1;
+    text-align: right;
+    flex-shrink: 0;
+  }
+}
+
+.euiProgress__valueText {
+  // Tabular numbers ensure the line up nicely when right-aligned
+  font-feature-settings: 'tnum' 1;
 }
 
 .euiProgress__data--l {

--- a/src/components/progress/progress.tsx
+++ b/src/components/progress/progress.tsx
@@ -26,6 +26,7 @@ import React, {
 } from 'react';
 import classNames from 'classnames';
 import { EuiI18n } from '../i18n';
+import { EuiInnerText } from '../inner_text';
 import { CommonProps, ExclusiveUnion } from '../common';
 import { isNil } from '../../services/predicate';
 
@@ -124,9 +125,6 @@ export const EuiProgress: FunctionComponent<ExclusiveUnion<
     {
       'euiProgress__data--l': size === 'l',
     },
-    {
-      'euiProgress__data--hasLabel': label,
-    },
     dataColorToClassNameMap[color]
   );
   const labelClasses = classNames(
@@ -134,9 +132,9 @@ export const EuiProgress: FunctionComponent<ExclusiveUnion<
     labelProps && labelProps.className
   );
 
-  let valueRender;
-  if (typeof valueText === 'boolean' && valueText) {
-    // valueText is a true boolean
+  let valueRender: ReactNode;
+  if (valueText === true) {
+    // valueText is true
     valueRender = (
       <EuiI18n
         token="euiProgress.valueText"
@@ -160,12 +158,29 @@ export const EuiProgress: FunctionComponent<ExclusiveUnion<
         {label || valueText ? (
           <div className={dataClasses}>
             {label && (
-              <span {...labelProps} className={labelClasses}>
-                {label}
-              </span>
+              <EuiInnerText>
+                {(ref, innerText) => (
+                  <span
+                    title={innerText}
+                    ref={ref}
+                    {...labelProps}
+                    className={labelClasses}>
+                    {label}
+                  </span>
+                )}
+              </EuiInnerText>
             )}
             {valueRender && (
-              <span className="euiProgress__valueText">{valueRender}</span>
+              <EuiInnerText>
+                {(ref, innerText) => (
+                  <span
+                    title={innerText}
+                    ref={ref}
+                    className="euiProgress__valueText">
+                    {valueRender}
+                  </span>
+                )}
+              </EuiInnerText>
             )}
           </div>
         ) : (


### PR DESCRIPTION
This reverts the need to add a new class to component simply when the `label` is present. You can easily adjust the styles of an element based on the presence of an element that comes before it with the sibling selector.


```scss
.euiProgress__label + .euiProgress__valueText {
  // These styles will only be added to the valueText element
  // if the label is present because it is dependent on being the 
  // next direct sibling of the label
}
```

This also adjusts how the flex is handled to prioritize the `valueText`. I know this seems backward because the more important piece of data is the label. However, for the use case of this particular instnace, I'm expecting engineers to have control over the size of the `value` by rounding and such, but they most likely won't have control over the `label`. So if they see there is like 18 decimals attached to the percentage forcing it to grow so wide the label falls off, they should be able to do `Math.round(value)` before passing it in.

### Before
<img width="251" alt="Screen Shot 2020-08-24 at 18 19 26 PM" src="https://user-images.githubusercontent.com/549577/91102067-72fc9600-e636-11ea-8649-b4d80b1c2bcd.png">



### After
<img width="226" alt="Screen Shot 2020-08-24 at 18 19 35 PM" src="https://user-images.githubusercontent.com/549577/91102073-75f78680-e636-11ea-8695-7dfa414330f4.png">
