### PR TITLE
Context menu follow up

### DIFF
--- a/src-docs/src/views/context_menu/context_menu_example.js
+++ b/src-docs/src/views/context_menu/context_menu_example.js
@@ -15,24 +15,44 @@ import {
 import ContextMenu from './context_menu';
 const contextMenuSource = require('!!raw-loader!./context_menu');
 const contextMenuHtml = renderToHtml(ContextMenu);
-const contextMenuSnippet = `<EuiContextMenu 
+const contextMenuSnippet = `<EuiContextMenu
   initialPanelId={0}
-  panels={panels} 
+  panels={[
+    {
+      id: 0,
+      title: 'This is a context menu',
+      items: [
+        {
+          name: 'Handle an onClick',
+          icon: <EuiIcon type="search" size="m" />,
+          onClick: () => {
+            closePopover();
+          },
+        },
+      ]
+    }
+  ]}
 />`;
 
 import SinglePanel from './single_panel';
 const singlePanelSource = require('!!raw-loader!./single_panel');
 const singlePanelHtml = renderToHtml(SinglePanel);
-const singlePanelSnippet = `<EuiContextMenuPanel 
-  items={items} 
+const singlePanelSnippet = `<EuiContextMenuPanel
+  items={[
+    <EuiContextMenuItem
+      key=""
+      onClick={}>
+      This is a context menu item
+    </EuiContextMenuItem>
+  ]}
 />`;
 
 import Small from './small';
 const smallSizeSource = require('!!raw-loader!./small');
 const smallSizeHtml = renderToHtml(SinglePanel);
-const smallSnippet = `<EuiContextMenuPanel 
+const smallSnippet = `<EuiContextMenuPanel
   size="s"
-  items={items} 
+  items={items}
 />`;
 
 import ContentPanel from './content_panel';
@@ -46,10 +66,6 @@ const contentPanelSnippet = `<EuiContextMenuPanel>
 import ContextMenuWithContent from './context_menu_with_content';
 const contextMenuWithContentSource = require('!!raw-loader!./context_menu_with_content');
 const contextMenuWithContentHtml = renderToHtml(ContextMenuWithContent);
-const contextMenuWithContentSnippet = `<EuiContextMenu 
-  initialPanelId={0} 
-  panels={dynamicPanels} 
-/>`;
 
 export const ContextMenuExample = {
   title: 'Context menu',
@@ -81,6 +97,32 @@ export const ContextMenuExample = {
       demo: <ContextMenu />,
     },
     {
+      title: 'Sizes',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: smallSizeSource,
+        },
+        {
+          type: GuideSectionTypes.HTML,
+          code: smallSizeHtml,
+        },
+      ],
+      text: (
+        <p>
+          <strong>EuiContextMenu</strong> supports a small and medium{' '}
+          <EuiCode>size</EuiCode>. The default size is medium,{' '}
+          <EuiCode>m</EuiCode>, and should be used for most menus and major
+          actions such as top application menus. Use the smaller size,{' '}
+          <EuiCode>s</EuiCode>, for a more compressed version containing minor
+          actions or repeated menus like in <strong>EuiTable</strong>{' '}
+          pagination.
+        </p>
+      ),
+      snippet: smallSnippet,
+      demo: <SinglePanel />,
+    },
+    {
       title: 'With single panel',
       source: [
         {
@@ -100,31 +142,6 @@ export const ContextMenuExample = {
         </p>
       ),
       snippet: singlePanelSnippet,
-      demo: <SinglePanel />,
-    },
-    {
-      title: 'Sizes',
-      source: [
-        {
-          type: GuideSectionTypes.JS,
-          code: smallSizeSource,
-        },
-        {
-          type: GuideSectionTypes.HTML,
-          code: smallSizeHtml,
-        },
-      ],
-      text: (
-        <p>
-          <strong>EuiContextMenu</strong> supports a small and medium{' '}
-          <EuiCode>size</EuiCode>. Use the default size <EuiCode>m</EuiCode> for
-          major actions such as <em>Share</em> and <em>Export</em> which appear
-          in top application menus. Use the smaller size <EuiCode>s</EuiCode>{' '}
-          for actions that affect only a single item or are repeated like in{' '}
-          <strong>EuiTable</strong> actions.
-        </p>
-      ),
-      snippet: smallSnippet,
       demo: <Small />,
     },
     {
@@ -186,7 +203,6 @@ export const ContextMenuExample = {
           </p>
         </div>
       ),
-      snippet: contextMenuWithContentSnippet,
       demo: <ContextMenuWithContent />,
     },
   ],

--- a/src-docs/src/views/context_menu/single_panel.js
+++ b/src-docs/src/views/context_menu/single_panel.js
@@ -80,7 +80,7 @@ export default () => {
       closePopover={closePopover}
       panelPaddingSize="none"
       anchorPosition="downLeft">
-      <EuiContextMenuPanel items={items} />
+      <EuiContextMenuPanel size="s" items={items} />
     </EuiPopover>
   );
 };

--- a/src-docs/src/views/context_menu/small.js
+++ b/src-docs/src/views/context_menu/small.js
@@ -19,27 +19,20 @@ export default () => {
   };
 
   const items = [
-    <EuiContextMenuItem
-      key="copy"
-      icon="copy"
-      onClick={() => {
-        closePopover();
-      }}>
+    <EuiContextMenuItem key="copy" icon="copy" onClick={closePopover}>
       Copy
     </EuiContextMenuItem>,
-    <EuiContextMenuItem
-      key="edit"
-      icon="pencil"
-      onClick={() => {
-        closePopover();
-      }}>
+    <EuiContextMenuItem key="edit" icon="pencil" onClick={closePopover}>
       Edit
+    </EuiContextMenuItem>,
+    <EuiContextMenuItem key="share" icon="share" onClick={closePopover}>
+      Share
     </EuiContextMenuItem>,
   ];
 
   const button = (
     <EuiButton iconType="arrowDown" iconSide="right" onClick={onButtonClick}>
-      Small context menu
+      Click to show a single panel
     </EuiButton>
   );
 
@@ -51,7 +44,7 @@ export default () => {
       closePopover={closePopover}
       panelPaddingSize="none"
       anchorPosition="downLeft">
-      <EuiContextMenuPanel items={items} size="s" />
+      <EuiContextMenuPanel size="s" items={items} />
     </EuiPopover>
   );
 };

--- a/src/components/context_menu/__snapshots__/context_menu.test.tsx.snap
+++ b/src/components/context_menu/__snapshots__/context_menu.test.tsx.snap
@@ -376,11 +376,11 @@ exports[`EuiContextMenu props size s is rendered 1`] = `
   class="euiContextMenu euiContextMenu--small"
 >
   <div
-    class="euiContextMenuPanel euiContextMenuPanel--small euiContextMenu__panel"
+    class="euiContextMenuPanel euiContextMenu__panel"
     tabindex="0"
   >
     <button
-      class="euiContextMenuPanelTitle"
+      class="euiContextMenuPanelTitle euiContextMenuPanelTitle--small"
       data-test-subj="contextMenuPanelTitleButton"
       type="button"
     >

--- a/src/components/context_menu/__snapshots__/context_menu_item.test.tsx.snap
+++ b/src/components/context_menu/__snapshots__/context_menu_item.test.tsx.snap
@@ -125,6 +125,36 @@ exports[`EuiContextMenuItem props rel is rendered 1`] = `
 </a>
 `;
 
+exports[`EuiContextMenuItem props size m is rendered 1`] = `
+<button
+  class="euiContextMenuItem"
+  type="button"
+>
+  <span
+    class="euiContextMenu__itemLayout"
+  >
+    <span
+      class="euiContextMenuItem__text"
+    />
+  </span>
+</button>
+`;
+
+exports[`EuiContextMenuItem props size s is rendered 1`] = `
+<button
+  class="euiContextMenuItem euiContextMenuItem--small"
+  type="button"
+>
+  <span
+    class="euiContextMenu__itemLayout"
+  >
+    <span
+      class="euiContextMenuItem__text"
+    />
+  </span>
+</button>
+`;
+
 exports[`EuiContextMenuItem props target is rendered 1`] = `
 <a
   aria-label="aria-label"

--- a/src/components/context_menu/__snapshots__/context_menu_panel.test.tsx.snap
+++ b/src/components/context_menu/__snapshots__/context_menu_panel.test.tsx.snap
@@ -376,11 +376,11 @@ exports[`EuiContextMenu props size s is rendered 1`] = `
   class="euiContextMenu euiContextMenu--small"
 >
   <div
-    class="euiContextMenuPanel euiContextMenuPanel--small euiContextMenu__panel"
+    class="euiContextMenuPanel euiContextMenu__panel"
     tabindex="0"
   >
     <button
-      class="euiContextMenuPanelTitle"
+      class="euiContextMenuPanelTitle euiContextMenuPanelTitle--small"
       data-test-subj="contextMenuPanelTitleButton"
       type="button"
     >

--- a/src/components/context_menu/__snapshots__/context_menu_panel.test.tsx.snap
+++ b/src/components/context_menu/__snapshots__/context_menu_panel.test.tsx.snap
@@ -454,6 +454,46 @@ exports[`EuiContextMenuPanel props onClose renders a button as a title 1`] = `
 </div>
 `;
 
+exports[`EuiContextMenuPanel props size m is rendered 1`] = `
+<div
+  class="euiContextMenuPanel"
+  tabindex="0"
+>
+  <div
+    class="euiContextMenuPanelTitle"
+  >
+    <span
+      class="euiContextMenu__itemLayout"
+    >
+      Title
+    </span>
+  </div>
+  <div>
+    <div />
+  </div>
+</div>
+`;
+
+exports[`EuiContextMenuPanel props size s is rendered 1`] = `
+<div
+  class="euiContextMenuPanel"
+  tabindex="0"
+>
+  <div
+    class="euiContextMenuPanelTitle euiContextMenuPanelTitle--small"
+  >
+    <span
+      class="euiContextMenu__itemLayout"
+    >
+      Title
+    </span>
+  </div>
+  <div>
+    <div />
+  </div>
+</div>
+`;
+
 exports[`EuiContextMenuPanel props title is rendered 1`] = `
 <div
   class="euiContextMenuPanel"

--- a/src/components/context_menu/_context_menu.scss
+++ b/src/components/context_menu/_context_menu.scss
@@ -11,13 +11,6 @@ $euiContextMenuWidth: $euiSize * 16;
   .euiContextMenu__content {
     padding: $euiSizeS;
   }
-
-  &--small {
-    .euiContextMenuPanelTitle {
-      @include euiTitle('xxxs');
-      padding: $euiSizeS * .75 $euiSizeS;
-    }
-  }
 }
 
 /**

--- a/src/components/context_menu/_context_menu_item.scss
+++ b/src/components/context_menu/_context_menu_item.scss
@@ -26,7 +26,7 @@
   }
 
   &--small {
-    padding: $euiSizeS * .75 $euiSizeS;
+    padding: ($euiSizeS * .75) $euiSizeS;
 
     .euiContextMenuItem__text {
       @include euiFontSizeS;
@@ -63,5 +63,3 @@
     flex-shrink: 0;
   }
 }
-
-

--- a/src/components/context_menu/_context_menu_panel.scss
+++ b/src/components/context_menu/_context_menu_panel.scss
@@ -45,6 +45,11 @@
   &:enabled:focus {
     text-decoration: underline;
   }
+
+  &--small {
+    @include euiPopoverTitle('s');
+    padding: ($euiSizeS * .75) $euiSizeS;
+  }
 }
 
 @keyframes euiContextMenuPanelTxInLeft {

--- a/src/components/context_menu/context_menu.test.tsx
+++ b/src/components/context_menu/context_menu.test.tsx
@@ -168,6 +168,7 @@ describe('EuiContextMenu', () => {
         expect(takeMountedSnapshot(component)).toMatchSnapshot();
       });
     });
+
     describe('size', () => {
       SIZES.forEach((size) => {
         it(`${size} is rendered`, () => {

--- a/src/components/context_menu/context_menu.tsx
+++ b/src/components/context_menu/context_menu.tsx
@@ -66,6 +66,9 @@ export interface EuiContextMenuPanelDescriptor {
   content?: ReactNode;
   width?: number;
   initialFocusedItemIndex?: number;
+  /**
+   * Alters the size of the items and the title
+   */
   size?: typeof SIZES[number];
 }
 
@@ -80,6 +83,9 @@ export type EuiContextMenuProps = CommonProps &
   Omit<HTMLAttributes<HTMLDivElement>, 'style'> & {
     panels?: EuiContextMenuPanelDescriptor[];
     initialPanelId?: EuiContextMenuPanelId;
+    /**
+     * Alters the size of the items and the title
+     */
     size?: typeof SIZES[number];
   };
 

--- a/src/components/context_menu/context_menu_item.test.tsx
+++ b/src/components/context_menu/context_menu_item.test.tsx
@@ -21,7 +21,7 @@ import React from 'react';
 import { render, shallow, mount } from 'enzyme';
 import { requiredProps } from '../../test/required_props';
 
-import { EuiContextMenuItem } from './context_menu_item';
+import { EuiContextMenuItem, SIZES } from './context_menu_item';
 
 describe('EuiContextMenuItem', () => {
   test('is rendered', () => {
@@ -48,6 +48,16 @@ describe('EuiContextMenuItem', () => {
         const component = render(<EuiContextMenuItem disabled />);
 
         expect(component).toMatchSnapshot();
+      });
+    });
+
+    describe('size', () => {
+      SIZES.forEach((size) => {
+        it(`${size} is rendered`, () => {
+          const component = render(<EuiContextMenuItem size={size} />);
+
+          expect(component).toMatchSnapshot();
+        });
       });
     });
 

--- a/src/components/context_menu/context_menu_item.tsx
+++ b/src/components/context_menu/context_menu_item.tsx
@@ -71,6 +71,9 @@ export interface EuiContextMenuItemProps extends CommonProps {
    * How to align icon with content of button
    */
   layoutAlign?: EuiContextMenuItemLayoutAlignment;
+  /**
+   * Reduce the size to `s` when in need of a more compressed menu
+   */
   size?: typeof SIZES[number];
 }
 

--- a/src/components/context_menu/context_menu_panel.test.tsx
+++ b/src/components/context_menu/context_menu_panel.test.tsx
@@ -21,7 +21,7 @@ import React from 'react';
 import { render, mount, ReactWrapper } from 'enzyme';
 import { findTestSubject, requiredProps } from '../../test';
 
-import { EuiContextMenuPanel } from './context_menu_panel';
+import { EuiContextMenuPanel, SIZES } from './context_menu_panel';
 
 import { EuiContextMenuItem } from './context_menu_item';
 
@@ -56,6 +56,18 @@ describe('EuiContextMenuPanel', () => {
         const component = render(<EuiContextMenuPanel title="Title" />);
 
         expect(component).toMatchSnapshot();
+      });
+    });
+
+    describe('size', () => {
+      SIZES.forEach((size) => {
+        it(`${size} is rendered`, () => {
+          const component = render(
+            <EuiContextMenuPanel title="Title" size={size} />
+          );
+
+          expect(component).toMatchSnapshot();
+        });
       });
     });
 

--- a/src/components/context_menu/context_menu_panel.tsx
+++ b/src/components/context_menu/context_menu_panel.tsx
@@ -61,6 +61,9 @@ export interface EuiContextMenuPanelProps {
   transitionDirection?: EuiContextMenuPanelTransitionDirection;
   transitionType?: EuiContextMenuPanelTransitionType;
   watchedItemProps?: string[];
+  /**
+   * Alters the size of the items and the title
+   */
   size?: typeof SIZES[number];
 }
 
@@ -496,7 +499,7 @@ export class EuiContextMenuPanel extends Component<Props, State> {
             MenuItem.type === EuiContextMenuItem
               ? cloneElement(MenuItem, {
                   buttonRef: this.menuItemRef.bind(this, index),
-                  size: this.props.size,
+                  size,
                 })
               : MenuItem
           )

--- a/src/components/context_menu/context_menu_panel.tsx
+++ b/src/components/context_menu/context_menu_panel.tsx
@@ -40,12 +40,12 @@ export type EuiContextMenuPanelShowPanelCallback = (
   currentPanelIndex?: number
 ) => void;
 
-const sizeToClassNameMap = {
-  s: 'euiContextMenuPanel--small',
+const titleSizeToClassNameMap = {
+  s: 'euiContextMenuPanelTitle--small',
   m: null,
 };
 
-export const SIZES = keysOf(sizeToClassNameMap);
+export const SIZES = keysOf(titleSizeToClassNameMap);
 
 export interface EuiContextMenuPanelProps {
   hasFocus?: boolean;
@@ -443,10 +443,15 @@ export class EuiContextMenuPanel extends Component<Props, State> {
     let panelTitle;
 
     if (title) {
+      const titleClasses = classNames(
+        'euiContextMenuPanelTitle',
+        size && titleSizeToClassNameMap[size]
+      );
+
       if (Boolean(onClose)) {
         panelTitle = (
           <button
-            className="euiContextMenuPanelTitle"
+            className={titleClasses}
             type="button"
             onClick={onClose}
             ref={(node) => {
@@ -466,7 +471,7 @@ export class EuiContextMenuPanel extends Component<Props, State> {
         );
       } else {
         panelTitle = (
-          <div className="euiContextMenuPanelTitle">
+          <div className={titleClasses}>
             <span className="euiContextMenu__itemLayout">{title}</span>
           </div>
         );
@@ -475,7 +480,6 @@ export class EuiContextMenuPanel extends Component<Props, State> {
 
     const classes = classNames(
       'euiContextMenuPanel',
-      size && sizeToClassNameMap[size],
       className,
       transitionDirection &&
         transitionType &&

--- a/src/global_styling/mixins/_popover.scss
+++ b/src/global_styling/mixins/_popover.scss
@@ -1,5 +1,12 @@
-@mixin euiPopoverTitle {
-  @include euiTitle('xxs');
+@mixin euiPopoverTitle($size: 'm') {
+  @if ($size == 's') {
+    @include euiTitle('xxxs');
+  } @else if ($size == 'm') {
+    @include euiTitle('xxs');
+  } @else {
+    @warn 'euiPopoverTitle only accepts "s" or "m" sizes';
+  }
+
   padding: $euiSizeM;
   text-transform: uppercase;
   border-bottom: $euiBorderThin;

--- a/src/themes/eui-amsterdam/global_styling/mixins/_index.scss
+++ b/src/themes/eui-amsterdam/global_styling/mixins/_index.scss
@@ -19,5 +19,6 @@
 @import '../../../../global_styling/mixins/panel';
 @import 'panel';
 @import '../../../../global_styling/mixins/popover';
+@import 'popover';
 @import '../../../../global_styling/mixins/range';
 @import '../../../../global_styling/mixins/tool_tip';

--- a/src/themes/eui-amsterdam/global_styling/mixins/_popover.scss
+++ b/src/themes/eui-amsterdam/global_styling/mixins/_popover.scss
@@ -1,0 +1,5 @@
+@mixin euiPopoverTitle($size: null) {
+  @include euiTitle('xxs');
+  padding: $euiSizeM;
+  border-bottom: $euiBorderThin;
+}

--- a/src/themes/eui-amsterdam/overrides/_context_menu.scss
+++ b/src/themes/eui-amsterdam/overrides/_context_menu.scss
@@ -1,5 +1,0 @@
-.euiContextMenu {
-  .euiContextMenuPanelTitle {
-    text-transform: none;
-  }
-}

--- a/src/themes/eui-amsterdam/overrides/_index.scss
+++ b/src/themes/eui-amsterdam/overrides/_index.scss
@@ -4,7 +4,6 @@
 @import 'button_group';
 @import 'call_out';
 @import 'code_block';
-@import 'context_menu';
 @import 'comment';
 @import 'date_picker';
 @import 'filter_group';

--- a/src/themes/eui-amsterdam/overrides/_popover.scss
+++ b/src/themes/eui-amsterdam/overrides/_popover.scss
@@ -68,13 +68,6 @@
   }
 }
 
-/**
- * Title specific overrides
- */
-
-.euiPopoverTitle {
-  text-transform: none;
-}
 
 // Mainly for specificity, but don't add padding to the title if
 // neither the the panel nor the title has a padding modifier (aka NONE)


### PR DESCRIPTION
Fixed up some examples:
- Swapped actual examples between Sizes and Single panel. The pagination example seems actually more appropriate to exemplify why one would want a small context menu so I just swapped those examples.
- Added a bit more to a few snippets

Created a specific small title class instead of relying on nesting …
- Also updated the `euiPopoverTitle()` mixin to accept a size prop and re-created it for Amsterdam for better adjustments. This required less actual override structures.

Added prop comments and a few more tests.
